### PR TITLE
Change queue name for exporter

### DIFF
--- a/app/jobs/product_exporter_job.rb
+++ b/app/jobs/product_exporter_job.rb
@@ -44,11 +44,11 @@ class ProductExporterJob < ApplicationJob
   def routing_key(action:)
     case action
     when :add
-      "ecommerce.product.add"
+      "cms.product.added"
     when :update
-      "ecommerce.product.update"
+      "cms.product.updated"
     when :delete
-      "ecommerce.product.delete"
+      "cms.product.deleted"
     end
   end
 end

--- a/spec/jobs/product_exporter_job_spec.rb
+++ b/spec/jobs/product_exporter_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ProductExporterJob, type: :job do
 
   it "should publish successfully for add" do
     expect(Hutch).to receive(:publish).with(
-      "ecommerce.product.add",
+      "ecommerce.product.added",
       product_id: product.contentful_id,
       product_type: product._type,
       product: {
@@ -28,7 +28,7 @@ RSpec.describe ProductExporterJob, type: :job do
 
   it "should publish successfully for update" do
     expect(Hutch).to receive(:publish).with(
-      "ecommerce.product.update",
+      "ecommerce.product.updated",
       product_id: product.contentful_id,
       product_type: product._type,
       product: {
@@ -44,7 +44,7 @@ RSpec.describe ProductExporterJob, type: :job do
 
   it "should publish successfully for delete" do
     expect(Hutch).to receive(:publish).with(
-      "ecommerce.product.delete",
+      "ecommerce.product.deleted",
       product_id: product.contentful_id
     )
 
@@ -54,21 +54,21 @@ RSpec.describe ProductExporterJob, type: :job do
 
   describe "#routing_key" do
     it "should use add queue" do
-      expect(Hutch).to receive(:publish).with("ecommerce.product.add", any_args)
+      expect(Hutch).to receive(:publish).with("ecommerce.product.added", any_args)
 
       action = :add
       exporter.perform_now(action: action, product_id: product.id.to_s)
     end
 
     it "should use update queue" do
-      expect(Hutch).to receive(:publish).with("ecommerce.product.update", any_args)
+      expect(Hutch).to receive(:publish).with("ecommerce.product.updated", any_args)
 
       action = :update
       exporter.perform_now(action: action, product_id: product.id.to_s)
     end
 
     it "should use delete queue" do
-      expect(Hutch).to receive(:publish).with("ecommerce.product.delete", any_args)
+      expect(Hutch).to receive(:publish).with("ecommerce.product.deleted", any_args)
 
       action = :delete
       exporter.perform_now(action: action, product_id: product.id.to_s)

--- a/spec/jobs/product_exporter_job_spec.rb
+++ b/spec/jobs/product_exporter_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ProductExporterJob, type: :job do
 
   it "should publish successfully for add" do
     expect(Hutch).to receive(:publish).with(
-      "ecommerce.product.added",
+      "cms.product.added",
       product_id: product.contentful_id,
       product_type: product._type,
       product: {
@@ -28,7 +28,7 @@ RSpec.describe ProductExporterJob, type: :job do
 
   it "should publish successfully for update" do
     expect(Hutch).to receive(:publish).with(
-      "ecommerce.product.updated",
+      "cms.product.updated",
       product_id: product.contentful_id,
       product_type: product._type,
       product: {
@@ -44,7 +44,7 @@ RSpec.describe ProductExporterJob, type: :job do
 
   it "should publish successfully for delete" do
     expect(Hutch).to receive(:publish).with(
-      "ecommerce.product.deleted",
+      "cms.product.deleted",
       product_id: product.contentful_id
     )
 
@@ -54,21 +54,21 @@ RSpec.describe ProductExporterJob, type: :job do
 
   describe "#routing_key" do
     it "should use add queue" do
-      expect(Hutch).to receive(:publish).with("ecommerce.product.added", any_args)
+      expect(Hutch).to receive(:publish).with("cms.product.added", any_args)
 
       action = :add
       exporter.perform_now(action: action, product_id: product.id.to_s)
     end
 
     it "should use update queue" do
-      expect(Hutch).to receive(:publish).with("ecommerce.product.updated", any_args)
+      expect(Hutch).to receive(:publish).with("cms.product.updated", any_args)
 
       action = :update
       exporter.perform_now(action: action, product_id: product.id.to_s)
     end
 
     it "should use delete queue" do
-      expect(Hutch).to receive(:publish).with("ecommerce.product.deleted", any_args)
+      expect(Hutch).to receive(:publish).with("cms.product.deleted", any_args)
 
       action = :delete
       exporter.perform_now(action: action, product_id: product.id.to_s)


### PR DESCRIPTION
We've decided to go with the paradigm of publishing an event, and having the orchestrator respond to that event. Therefore, instead of issuing commands to the orchestrator, we will publish that an action happened, and allow the orchestrator to respond to that