### PR TITLE
Optimize CI by adding depends_on in docker-compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
       run: |
         docker login ghcr.io -u $GITHUB_ACTOR --password-stdin <<< ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
         export IMAGE_TAG=$GITHUB_SHA
-        docker-compose up -d
         script/test
-        docker-compose down
       env:
         IMAGE_NAME: ghcr.io/${{ github.event.repository.owner.login }}/for-testing/${{ github.event.repository.name }}
         CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - network
     ports:
       - "4000:3000"
+    depends_on:
+      - mongo
 
   hutch:
     restart: always


### PR DESCRIPTION
If we had depends_on, we don't have to do a 'docker-compose up' to run tests.